### PR TITLE
Optimized NotNullOrEmtpy for IEnumerable values. Closes #3

### DIFF
--- a/src/Validation/Requires.cs
+++ b/src/Validation/Requires.cs
@@ -7,6 +7,7 @@
 namespace Validation
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
@@ -189,17 +190,29 @@ namespace Validation
                 throw new ArgumentNullException(parameterName);
             }
 
-            bool hasElements = false;
-            foreach (object value in values)
-            {
-                hasElements = true;
-                break;
-            }
+            ICollection collection = values as ICollection;
 
-            if (!hasElements)
+            if (collection != null)
             {
+                if (collection.Count > 0)
+                {
+                    return;    
+                }
+
                 throw new ArgumentException(Format(Strings.Argument_EmptyArray, parameterName), parameterName);
             }
+
+            IEnumerator enumerator = values.GetEnumerator();
+
+            using (enumerator as IDisposable)
+            {
+                if (enumerator.MoveNext())
+                {
+                    return;
+                }
+            }
+
+            throw new ArgumentException(Format(Strings.Argument_EmptyArray, parameterName), parameterName);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR implements the suggestion made in issue #3 to optimize the `NotNullOrEmpty` method that takes an `IEnumerable`. I have further optimized the `ICollection` part to throw when the `Count` is not equal to `1`.
