### PR TITLE
Adding NotDefault method to check structs values against default values.

### DIFF
--- a/src/Validation/Requires.cs
+++ b/src/Validation/Requires.cs
@@ -126,7 +126,7 @@ namespace Validation
         public static void NotNullOrEmpty([ValidatedNotNull]string value, string parameterName)
         {
             // To the guy that is doing random code cleaning:
-            // Consider the perfomance when changing the code to delegate to NotNull.
+            // Consider the performance when changing the code to delegate to NotNull.
             // In general do not chain call to another function, check first and return as earlier as possible.
             if (value == null)
             {
@@ -150,7 +150,7 @@ namespace Validation
         public static void NotNullOrWhiteSpace([ValidatedNotNull]string value, string parameterName)
         {
             // To the guy that is doing random code cleaning:
-            // Consider the perfomance when changing the code to delegate to NotNull.
+            // Consider the performance when changing the code to delegate to NotNull.
             // In general do not chain call to another function, check first and return as earlier as possible.
             if (value == null)
             {
@@ -180,7 +180,7 @@ namespace Validation
         public static void NotNullOrEmpty([ValidatedNotNull]System.Collections.IEnumerable values, string parameterName)
         {
             // To the guy that is doing random code cleaning:
-            // Consider the perfomance when changing the code to delegate to NotNull.
+            // Consider the performance when changing the code to delegate to NotNull.
             // In general do not chain call to another function, check first and return as earlier as possible.
             if (values == null)
             {
@@ -313,6 +313,25 @@ namespace Validation
             if (!Enum.IsDefined(typeof(T), value))
             {
                 throw new ArgumentException(Format(Strings.Argument_EnumNotDefined, parameterName, typeof(T).FullName), parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> if the specified parameter's value is equal to the 
+        /// default value of the <see cref="Type"/> <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the parameter.</typeparam>
+        /// <param name="value">The value of the argument.</param>
+        /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <c>null</c> or empty.</exception>
+        [DebuggerStepThrough]
+        public static void NotDefault<T>(T value, string parameterName)
+            where T : struct
+        {
+            var defaultValue = default(T);
+            if (defaultValue.Equals(value))
+            {
+                throw new ArgumentException(Format(Strings.Argument_StructIsDefault, parameterName, typeof(T).FullName), parameterName);
             }
         }
 

--- a/src/Validation/Strings.Designer.cs
+++ b/src/Validation/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace Validation {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -94,6 +94,15 @@ namespace Validation {
         internal static string Argument_NullElement {
             get {
                 return ResourceManager.GetString("Argument_NullElement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot be the default value defined by &apos;{1}&apos;..
+        /// </summary>
+        internal static string Argument_StructIsDefault {
+            get {
+                return ResourceManager.GetString("Argument_StructIsDefault", resourceCulture);
             }
         }
         

--- a/src/Validation/Strings.resx
+++ b/src/Validation/Strings.resx
@@ -129,6 +129,9 @@
   <data name="Argument_NullElement" xml:space="preserve">
     <value>'{0}' cannot contain a null (Nothing in Visual Basic) element.</value>
   </data>
+  <data name="Argument_StructIsDefault" xml:space="preserve">
+    <value>'{0}' cannot be the default value defined by '{1}'.</value>
+  </data>
   <data name="Argument_Whitespace" xml:space="preserve">
     <value>The parameter "{0}" cannot consist entirely of white space characters.</value>
   </data>

--- a/src/Validation/Validation.csproj
+++ b/src/Validation/Validation.csproj
@@ -20,6 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="tools\**">
       <Pack>true</Pack>
       <PackagePath>tools\%(RecursiveDir)%(FileName)%(Extension)</PackagePath>


### PR DESCRIPTION
Useful for checks like:
```csharp
int x = 0;
Requires.NotDefault(x); // should throw
```

```csharp
enum Foo { None = 0, First = 1, ... }

var foo = Foo.None;
Requires.NotDefault(foo); // should throw
```

Closes #28