### PR TITLE
Updated XML documentation syntax.

### DIFF
--- a/src/Validation/Assumes.cs
+++ b/src/Validation/Assumes.cs
@@ -18,7 +18,7 @@ namespace Validation
     public static partial class Assumes
     {
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is null.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -30,7 +30,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is null.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -42,7 +42,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is null or empty.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is <see langword="null"/> or empty.
         /// </summary>
         [DebuggerStepThrough]
         public static void NotNullOrEmpty([ValidatedNotNull, NotNull] string? value)
@@ -53,7 +53,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is null or empty.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is <see langword="null"/> or empty.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -64,7 +64,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is null or empty.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is <see langword="null"/> or empty.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -75,7 +75,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is not null.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is not <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -87,7 +87,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws <see cref="InternalErrorException" /> if the specified value is not null.
+        /// Throws <see cref="InternalErrorException" /> if the specified value is not <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of value to test.</typeparam>
         [DebuggerStepThrough]
@@ -241,7 +241,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Verifies that a value is not null, and throws <see cref="InternalErrorException" /> about a missing service otherwise.
+        /// Verifies that a value is not <see langword="null"/>, and throws <see cref="InternalErrorException" /> about a missing service otherwise.
         /// </summary>
         /// <typeparam name="T">The interface of the imported part.</typeparam>
         [DebuggerStepThrough]

--- a/src/Validation/Report.cs
+++ b/src/Validation/Report.cs
@@ -18,7 +18,7 @@ namespace Validation
     public static class Report
     {
         /// <summary>
-        /// Verifies that a value is not null, and reports an error about a missing MEF component otherwise.
+        /// Verifies that a value is not <see langword="null"/>, and reports an error about a missing MEF component otherwise.
         /// </summary>
         /// <typeparam name="T">The interface of the imported part.</typeparam>
         [Conditional("DEBUG")]

--- a/src/Validation/Requires.cs
+++ b/src/Validation/Requires.cs
@@ -18,13 +18,13 @@ namespace Validation
     public static class Requires
     {
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of the parameter.</typeparam>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
         /// <returns>The value of the parameter.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
         [DebuggerStepThrough]
         [TargetedPatchingOptOut("Performance critical to inline across NGen image boundaries")]
         public static T NotNull<T>([ValidatedNotNull, NotNull] T value, string? parameterName)
@@ -58,11 +58,11 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>.
         /// </summary>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
         /// <remarks>
         /// This method allows async methods to use Requires.NotNull without having to assign the result
         /// to local variables to avoid C# warnings.
@@ -78,12 +78,12 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of the return value of the task.</typeparam>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
         /// <remarks>
         /// This method allows async methods to use Requires.NotNull without having to assign the result
         /// to local variables to avoid C# warnings.
@@ -99,16 +99,16 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">The type of the parameter.</typeparam>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
         /// <returns>The value of the parameter.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
         /// <remarks>
         /// This method exists for callers who themselves only know the type as a generic parameter which
-        /// may or may not be a class, but certainly cannot be null.
+        /// may or may not be a class, but certainly cannot be <see langword="null"/>.
         /// </remarks>
         [DebuggerStepThrough]
         public static T NotNullAllowStructs<T>([ValidatedNotNull, NotNull] T value, string? parameterName)
@@ -122,11 +122,11 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null or empty.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/> or empty.
         /// </summary>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <c>null</c> or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <see langword="null"/> or empty.</exception>
         [DebuggerStepThrough]
         public static void NotNullOrEmpty([ValidatedNotNull, NotNull] string value, string? parameterName)
         {
@@ -145,11 +145,11 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null, empty, or whitespace.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>, empty, or whitespace.
         /// </summary>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <c>null</c> or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <see langword="null"/> or empty.</exception>
         [DebuggerStepThrough]
         public static void NotNullOrWhiteSpace([ValidatedNotNull, NotNull] string value, string? parameterName)
         {
@@ -173,7 +173,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null,
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>,
         /// has no elements.
         /// </summary>
         /// <param name="values">The value of the argument.</param>
@@ -201,7 +201,7 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null,
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>,
         /// has no elements.
         /// </summary>
         /// <typeparam name="T">The type produced by the enumeration.</typeparam>
@@ -227,8 +227,8 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is null,
-        /// has no elements or has an element with a null value.
+        /// Throws an exception if the specified parameter's value is <see langword="null"/>,
+        /// has no elements or has an element with a <see langword="null"/> value.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
         /// <param name="values">The value of the argument.</param>
@@ -264,8 +264,8 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if the specified parameter's value is not null
-        /// <em>and</em> has an element with a null value.
+        /// Throws an exception if the specified parameter's value is not <see langword="null"/>
+        /// <em>and</em> has an element with a <see langword="null"/> value.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
         /// <param name="values">The value of the argument.</param>
@@ -427,7 +427,7 @@ namespace Validation
         /// <typeparam name="T">The type of the parameter.</typeparam>
         /// <param name="value">The value of the argument.</param>
         /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <c>null</c> or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is <see langword="null"/> or empty.</exception>
         [DebuggerStepThrough]
         public static void NotDefault<T>(T value, string parameterName)
             where T : struct
@@ -457,8 +457,8 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if <paramref name="values"/> is null,
-        /// <paramref name="predicate"/> is null, or if <paramref name="values"/> is not null
+        /// Throws an exception if <paramref name="values"/> is <see langword="null"/>,
+        /// <paramref name="predicate"/> is <see langword="null"/>, or if <paramref name="values"/> is not <see langword="null"/>
         /// <em>and</em> has an element which does not match the given predicate.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
@@ -494,8 +494,8 @@ namespace Validation
         }
 
         /// <summary>
-        /// Throws an exception if <paramref name="values"/> is null,
-        /// <paramref name="predicate"/> is null, or if <paramref name="values"/> is not null
+        /// Throws an exception if <paramref name="values"/> is <see langword="null"/>,
+        /// <paramref name="predicate"/> is <see langword="null"/>, or if <paramref name="values"/> is not <see langword="null"/>
         /// <em>and</em> has an element which does not match the given predicate.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the sequence.</typeparam>

--- a/src/Validation/Strings.Designer.cs
+++ b/src/Validation/Strings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Validation {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Validation {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Strings() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Validation {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Validation {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; must contain at least one element..
         /// </summary>
@@ -68,16 +68,16 @@ namespace Validation {
                 return ResourceManager.GetString("Argument_EmptyArray", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; cannot be an empty string (&quot;&quot;) or start with the null character..
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot be an empty string (&quot;&quot;) or start with the <see langword="null"/> character..
         /// </summary>
         internal static string Argument_EmptyString {
             get {
                 return ResourceManager.GetString("Argument_EmptyString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; must be set to a value defined by the enum &apos;{1}&apos;..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Validation {
                 return ResourceManager.GetString("Argument_EnumNotDefined", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value of argument &apos;{0}&apos; ({1}) is invalid for Enum type &apos;{2}&apos;..
         /// </summary>
@@ -95,16 +95,16 @@ namespace Validation {
                 return ResourceManager.GetString("Argument_NotEnum", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; cannot contain a null (Nothing in Visual Basic) element..
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot contain a <see langword="null"/> (Nothing in Visual Basic) element..
         /// </summary>
         internal static string Argument_NullElement {
             get {
                 return ResourceManager.GetString("Argument_NullElement", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; cannot be the default value defined by &apos;{1}&apos;..
         /// </summary>
@@ -113,7 +113,7 @@ namespace Validation {
                 return ResourceManager.GetString("Argument_StructIsDefault", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The argument cannot consist entirely of white space characters..
         /// </summary>
@@ -122,7 +122,7 @@ namespace Validation {
                 return ResourceManager.GetString("Argument_Whitespace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An internal error occurred. Please contact customer support..
         /// </summary>
@@ -131,7 +131,7 @@ namespace Validation {
                 return ResourceManager.GetString("InternalExceptionMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value of argument &apos;{0}&apos; ({1}) is invalid for Enum type &apos;{2}&apos;..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Validation {
                 return ResourceManager.GetString("InvalidEnumArgument", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cannot find an instance of the {0} service..
         /// </summary>


### PR DESCRIPTION
### **XML Documentation Syntax**

- Updated XML documentation "null" statements to use `<see langword="null"/>` syntax.
